### PR TITLE
Small typos in superposition and CNOT

### DIFF
--- a/pages/tutorials/cnot-entanglement/1-other-two-qubit-gates.page.tsx
+++ b/pages/tutorials/cnot-entanglement/1-other-two-qubit-gates.page.tsx
@@ -78,7 +78,7 @@ export default page(setup, ({ section, hint }) => ({
           <Matrix
             matrix={[
               ["1", "0", "0", "0"],
-              ["1", "1", "0", "0"],
+              ["0", "1", "0", "0"],
               [
                 "0",
                 "0",

--- a/pages/tutorials/interpreting-superpositions/2-superposition-v-mixed.page.tsx
+++ b/pages/tutorials/interpreting-superpositions/2-superposition-v-mixed.page.tsx
@@ -118,7 +118,7 @@ export default page(setup, ({ section, hint }) => ({
             indistinguishable from Alice's, since (after all) both are
             effectively "50/50, 0 or 1" boxes. <br />
             <br />
-            Try to decide, Alice and Bob each produce a large number of qubits
+            Trying to decide, Alice and Bob each produce a large number of qubits
             and measure each qubit to be a 0 or 1. They can only make
             measurements of 0 or 1. After measuring many qubits:{" "}
           </Prose>

--- a/pages/tutorials/interpreting-superpositions/2-superposition-v-mixed.page.tsx
+++ b/pages/tutorials/interpreting-superpositions/2-superposition-v-mixed.page.tsx
@@ -118,8 +118,8 @@ export default page(setup, ({ section, hint }) => ({
             indistinguishable from Alice's, since (after all) both are
             effectively "50/50, 0 or 1" boxes. <br />
             <br />
-            Trying to decide, Alice and Bob each produce a large number of qubits
-            and measure each qubit to be a 0 or 1. They can only make
+            Trying to decide, Alice and Bob each produce a large number of
+            qubits and measure each qubit to be a 0 or 1. They can only make
             measurements of 0 or 1. After measuring many qubits:{" "}
           </Prose>
           <Decimal


### PR DESCRIPTION
Fixed try to "trying" in superposition page 1
Fixed typo in figure for CNOT matrix on page 1 of that tutorial